### PR TITLE
feat: 불량 처리 모드 UI/UX 대폭 개선

### DIFF
--- a/Inspection_worker.py
+++ b/Inspection_worker.py
@@ -1144,254 +1144,92 @@ class InspectionProgram:
         """불량 처리 모드의 UI를 생성합니다."""
         self.defective_view_frame = ttk.Frame(container, style='TFrame')
         self.defective_view_frame.grid(row=0, column=0, sticky='nsew')
-        self.defective_view_frame.grid_columnconfigure(0, weight=1)
         self.defective_view_frame.grid_columnconfigure(1, weight=1)
-        self.defective_view_frame.grid_rowconfigure(1, weight=1)
+        self.defective_view_frame.grid_columnconfigure(0, weight=1)
+        self.defective_view_frame.grid_rowconfigure(0, weight=1)
 
-        # --- 왼쪽: 전체 불량 현황 ---
-        left_frame = ttk.Frame(self.defective_view_frame, style='TFrame')
-        left_frame.grid(row=0, column=0, rowspan=2, sticky='nsew', padx=(20, 10), pady=10)
-        left_frame.grid_rowconfigure(1, weight=1)
-        left_frame.grid_columnconfigure(0, weight=1)
+        # --- 왼쪽: 불량품 목록 (상/하 분리) ---
+        left_paned_window = ttk.PanedWindow(self.defective_view_frame, orient=tk.VERTICAL)
+        left_paned_window.grid(row=0, column=0, sticky='nsew', padx=(20, 10), pady=10)
 
-        ttk.Label(left_frame, text="처리 가능 불량품 목록 (전체 작업자)", style='TLabel', font=(self.DEFAULT_FONT, int(12 * self.scale_factor), 'bold')).grid(row=0, column=0, sticky='w')
+        unprocessed_frame = ttk.Frame(left_paned_window)
+        unprocessed_frame.grid_rowconfigure(1, weight=1)
+        unprocessed_frame.grid_columnconfigure(0, weight=1)
+        ttk.Label(unprocessed_frame, text="미처리 불량품 목록", style='TLabel', font=(self.DEFAULT_FONT, int(12 * self.scale_factor), 'bold')).grid(row=0, column=0, sticky='w')
 
-        cols = ('item_name', 'item_code', 'worker', 'count')
-        self.available_defects_tree = ttk.Treeview(left_frame, columns=cols, show='headings')
-        self.available_defects_tree.grid(row=1, column=0, sticky='nsew')
-        self.available_defects_tree.heading('item_name', text='품목명')
-        self.available_defects_tree.heading('item_code', text='품목코드')
-        self.available_defects_tree.heading('worker', text='작업자')
-        self.available_defects_tree.heading('count', text='수량')
-        self.available_defects_tree.column('item_code', width=100, anchor='center')
-        self.available_defects_tree.column('worker', width=80, anchor='center')
-        self.available_defects_tree.column('count', width=60, anchor='center')
+        cols_unprocessed = ('item_name', 'item_code', 'unprocessed_count')
+        self.unprocessed_defects_tree = ttk.Treeview(unprocessed_frame, columns=cols_unprocessed, show='headings')
+        self.unprocessed_defects_tree.grid(row=1, column=0, sticky='nsew')
+        self.unprocessed_defects_tree.heading('item_name', text='품목명')
+        self.unprocessed_defects_tree.heading('item_code', text='품목코드')
+        self.unprocessed_defects_tree.heading('unprocessed_count', text='수량')
+        self.unprocessed_defects_tree.column('item_code', width=120, anchor='center')
+        self.unprocessed_defects_tree.column('unprocessed_count', width=60, anchor='center')
+        left_paned_window.add(unprocessed_frame, weight=2)
 
-        # --- 오른쪽: 불량품 합치기 세션 ---
+        processed_frame = ttk.Frame(left_paned_window)
+        processed_frame.grid_rowconfigure(1, weight=1)
+        processed_frame.grid_columnconfigure(0, weight=1)
+        ttk.Label(processed_frame, text="처리완료 불량품 목록", style='TLabel', font=(self.DEFAULT_FONT, int(12 * self.scale_factor), 'bold')).grid(row=0, column=0, sticky='w')
+
+        cols_processed = ('item_name', 'item_code', 'processed_count')
+        self.processed_defects_tree = ttk.Treeview(processed_frame, columns=cols_processed, show='headings')
+        self.processed_defects_tree.grid(row=1, column=0, sticky='nsew')
+        self.processed_defects_tree.heading('item_name', text='품목명')
+        self.processed_defects_tree.heading('item_code', text='품목코드')
+        self.processed_defects_tree.heading('processed_count', text='수량')
+        self.processed_defects_tree.column('item_code', width=120, anchor='center')
+        self.processed_defects_tree.column('processed_count', width=60, anchor='center')
+        self.processed_defects_tree.tag_configure('processed_item', foreground='gray')
+        left_paned_window.add(processed_frame, weight=1)
+
+        # --- 오른쪽: 기능 영역 ---
         right_frame = ttk.Frame(self.defective_view_frame, style='TFrame')
-        right_frame.grid(row=0, column=1, rowspan=2, sticky='nsew', padx=(10, 20), pady=10)
-        right_frame.grid_rowconfigure(2, weight=1)
+        right_frame.grid(row=0, column=1, sticky='nsew', padx=(10, 20), pady=10)
         right_frame.grid_columnconfigure(0, weight=1)
+        right_frame.grid_rowconfigure(1, weight=3)
+        right_frame.grid_rowconfigure(3, weight=1)
 
-        session_ctrl_frame = ttk.Frame(right_frame, style='TFrame')
-        session_ctrl_frame.grid(row=0, column=0, sticky='ew', pady=(0, 10))
-        session_ctrl_frame.grid_columnconfigure(1, weight=1)
+        merge_frame = ttk.LabelFrame(right_frame, text="불량 합치기", style='Card.TFrame', padding=10)
+        merge_frame.grid(row=0, column=0, rowspan=2, sticky='nsew')
+        merge_frame.grid_columnconfigure(0, weight=1)
+        merge_frame.grid_rowconfigure(1, weight=1)
 
-        self.defect_session_label = ttk.Label(session_ctrl_frame, text="'불량 합치기'를 시작하거나 불량표를 바로 스캔하세요.", style='TLabel')
-        self.defect_session_label.grid(row=0, column=0, columnspan=2, sticky='w')
+        self.defect_session_label = ttk.Label(merge_frame, text="합칠 불량품/불량표를 스캔하세요. (목록 더블클릭 가능)", background=self.COLOR_SIDEBAR_BG)
+        self.defect_session_label.grid(row=0, column=0, sticky='w', pady=(0, 5))
 
-        ttk.Label(session_ctrl_frame, text="목표수량:", style='TLabel').grid(row=1, column=0, sticky='w', pady=5)
-        self.defect_target_qty_spinbox = ttk.Spinbox(session_ctrl_frame, from_=1, to=200, increment=1, width=5)
-        # 불량품 통합 모드 기본 목표 수량: 48개
-        self.defect_target_qty_spinbox.set(48)
-        self.defect_target_qty_spinbox.grid(row=1, column=1, sticky='w', pady=5)
-
-        self.start_defect_merge_button = ttk.Button(session_ctrl_frame, text="불량 합치기 시작", command=self.start_defective_merge_session, state=tk.DISABLED)
-        self.start_defect_merge_button.grid(row=2, column=0, pady=5, sticky='w')
-
-        self.scan_entry_defective = tk.Entry(right_frame, justify='center', font=(self.DEFAULT_FONT, int(20 * self.scale_factor), 'bold'), bd=2, relief=tk.SOLID, highlightbackground=self.COLOR_BORDER, highlightcolor=self.COLOR_DEFECT, highlightthickness=3, state=tk.DISABLED)
-        self.scan_entry_defective.grid(row=1, column=0, sticky='ew', ipady=int(10 * self.scale_factor))
+        self.scan_entry_defective = tk.Entry(merge_frame, justify='center', font=(self.DEFAULT_FONT, int(20 * self.scale_factor), 'bold'), bd=2, relief=tk.SOLID, highlightbackground=self.COLOR_BORDER, highlightcolor=self.COLOR_DEFECT, highlightthickness=3)
+        self.scan_entry_defective.grid(row=1, column=0, sticky='ew', ipady=int(10 * self.scale_factor), pady=5)
         self.scan_entry_defective.bind('<Return>', self.process_scan)
 
-        scanned_list_frame = ttk.Frame(right_frame, style='TFrame')
-        scanned_list_frame.grid(row=2, column=0, sticky='nsew', pady=(10,0))
+        scanned_list_frame = ttk.Frame(merge_frame, background=self.COLOR_SIDEBAR_BG)
+        scanned_list_frame.grid(row=2, column=0, sticky='nsew', pady=(5,0))
         scanned_list_frame.grid_rowconfigure(0, weight=1)
         scanned_list_frame.grid_columnconfigure(0, weight=1)
-
-        self.scanned_defects_tree = ttk.Treeview(scanned_list_frame, columns=('no', 'barcode'), show='headings')
+        self.scanned_defects_tree = ttk.Treeview(scanned_list_frame, columns=('no', 'barcode'), show='headings', height=5)
         self.scanned_defects_tree.grid(row=0, column=0, sticky='nsew')
         self.scanned_defects_tree.heading('no', text='No.')
         self.scanned_defects_tree.heading('barcode', text='스캔된 불량품 바코드')
         self.scanned_defects_tree.column('no', width=50, anchor='center')
 
-        bottom_button_frame = ttk.Frame(right_frame, style='TFrame')
+        bottom_button_frame = ttk.Frame(merge_frame, background=self.COLOR_SIDEBAR_BG)
         bottom_button_frame.grid(row=3, column=0, sticky='e', pady=(10, 0))
         self.cancel_defect_merge_button = ttk.Button(bottom_button_frame, text="취소", command=self.cancel_defective_merge_session, state=tk.DISABLED)
         self.cancel_defect_merge_button.pack(side=tk.LEFT, padx=5)
-        # 불량표 수동 생성 버튼 (2번째 생성 시기)
         self.generate_defect_label_button = ttk.Button(bottom_button_frame, text="불량표 생성", command=self.generate_defective_label, state=tk.DISABLED)
         self.generate_defect_label_button.pack(side=tk.LEFT, padx=5)
 
-        self.available_defects_tree.bind('<<TreeviewSelect>>', self.on_available_defect_select)
-        self.available_defects_tree.bind('<Double-1>', self.on_available_defect_double_click)
+        manual_add_frame = ttk.LabelFrame(right_frame, text="개별 불량 입력", style='Card.TFrame', padding=10)
+        manual_add_frame.grid(row=2, column=0, sticky='nsew', pady=(20, 0))
+        manual_add_frame.grid_columnconfigure(0, weight=1)
 
-    def on_available_defect_select(self, event=None):
-        if not self.available_defects_tree.selection():
-            self.start_defect_merge_button.config(state=tk.DISABLED)
-            return
+        ttk.Label(manual_add_frame, text="등록할 불량품 바코드를 스캔하세요.", background=self.COLOR_SIDEBAR_BG).pack(anchor='w')
+        self.scan_entry_manual_defect = tk.Entry(manual_add_frame, justify='center', font=(self.DEFAULT_FONT, int(16 * self.scale_factor), 'bold'), bd=2, relief=tk.SOLID, highlightbackground=self.COLOR_BORDER, highlightcolor=self.COLOR_PRIMARY, highlightthickness=2)
+        self.scan_entry_manual_defect.pack(fill=tk.X, ipady=8, pady=(5,10))
+        self.scan_entry_manual_defect.bind('<Return>', self._process_manual_defect_scan)
 
-        if self.current_defective_merge_session.item_code:
-            self.start_defect_merge_button.config(state=tk.DISABLED)
-        else:
-            self.start_defect_merge_button.config(state=tk.NORMAL)
+        self.unprocessed_defects_tree.bind('<Double-1>', self.on_unprocessed_defect_double_click)
 
-    def on_available_defect_double_click(self, event=None):
-        """불량품 목록 더블클릭 시 관련 동작 메뉴 표시"""
-        if not self.available_defects_tree.selection():
-            return
-
-        selection = self.available_defects_tree.selection()[0]
-        item_values = self.available_defects_tree.item(selection, 'values')
-        if len(item_values) < 4:
-            return
-
-        item_name, item_code, worker, count = item_values
-
-        # 컨텍스트 메뉴 생성
-        context_menu = tk.Menu(self.root, tearoff=0)
-
-        # 불량 합치기 시작
-        if not self.current_defective_merge_session.item_code:
-            context_menu.add_command(
-                label=f"🔗 '{item_name}' 불량 합치기 시작",
-                command=lambda: self._start_defect_merge_from_menu(item_code)
-            )
-
-        # 불량품 세부 정보 보기
-        context_menu.add_command(
-            label=f"📋 '{item_name}' 불량품 세부 정보 보기",
-            command=lambda: self._show_defect_details(item_code, worker)
-        )
-
-        # 불량표 즉시 생성 (기존 불량품으로)
-        context_menu.add_command(
-            label=f"🏷️ '{item_name}' 불량표 즉시 생성",
-            command=lambda: self._generate_instant_defect_label(item_code, worker)
-        )
-
-        context_menu.add_separator()
-
-        # 불량품 삭제 (관리자 기능)
-        context_menu.add_command(
-            label=f"🗑️ '{item_name}' 불량품 목록에서 제거",
-            command=lambda: self._remove_defects_from_list(item_code, worker)
-        )
-
-        # 마우스 위치에 메뉴 표시
-        try:
-            context_menu.tk_popup(event.x_root, event.y_root)
-        finally:
-            context_menu.grab_release()
-
-    def _start_defect_merge_from_menu(self, item_code):
-        """메뉴에서 불량 합치기 시작"""
-        # 해당 품목을 선택하고 세션 시작
-        for child in self.available_defects_tree.get_children():
-            item_values = self.available_defects_tree.item(child, 'values')
-            if len(item_values) > 1 and item_values[1] == item_code:
-                self.available_defects_tree.selection_set(child)
-                self.available_defects_tree.focus(child)
-                break
-
-        self.start_defective_merge_session()
-        self.show_status_message(f"'{item_code}' 불량 합치기를 시작했습니다.", self.COLOR_SUCCESS)
-
-    def _show_defect_details(self, item_code, worker):
-        """불량품 세부 정보 표시"""
-        defect_key = f"{item_code}_{worker}"
-        defect_info = self.available_defects.get(defect_key, {})
-        barcodes = defect_info.get('barcodes', set())
-
-        # 팝업 창 생성
-        popup = tk.Toplevel(self.root)
-        popup.title(f"불량품 세부 정보 - {item_code}")
-        popup.geometry("600x400")
-        popup.transient(self.root)
-        popup.grab_set()
-
-        main_frame = ttk.Frame(popup, padding=20)
-        main_frame.pack(fill=tk.BOTH, expand=True)
-
-        # 정보 표시
-        info_frame = ttk.LabelFrame(main_frame, text="불량품 정보", padding=10)
-        info_frame.pack(fill=tk.X, pady=(0, 10))
-
-        ttk.Label(info_frame, text=f"품목코드: {item_code}", font=('맑은 고딕', 12, 'bold')).pack(anchor='w')
-        ttk.Label(info_frame, text=f"작업자: {worker}", font=('맑은 고딕', 10)).pack(anchor='w')
-        ttk.Label(info_frame, text=f"불량품 수량: {len(barcodes)}개", font=('맑은 고딕', 10)).pack(anchor='w')
-
-        # 바코드 목록
-        barcode_frame = ttk.LabelFrame(main_frame, text="불량품 바코드 목록", padding=10)
-        barcode_frame.pack(fill=tk.BOTH, expand=True, pady=(0, 10))
-
-        # 바코드 리스트박스
-        listbox_frame = ttk.Frame(barcode_frame)
-        listbox_frame.pack(fill=tk.BOTH, expand=True)
-
-        scrollbar = ttk.Scrollbar(listbox_frame)
-        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
-
-        barcode_listbox = tk.Listbox(listbox_frame, yscrollcommand=scrollbar.set, font=('맑은 고딕', 9))
-        barcode_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        scrollbar.config(command=barcode_listbox.yview)
-
-        # 바코드 추가
-        for barcode in sorted(barcodes):
-            barcode_listbox.insert(tk.END, barcode)
-
-        # 버튼 프레임
-        button_frame = ttk.Frame(main_frame)
-        button_frame.pack(fill=tk.X)
-
-        ttk.Button(button_frame, text="닫기", command=popup.destroy).pack(side=tk.RIGHT)
-
-    def _generate_instant_defect_label(self, item_code, worker):
-        """선택된 불량품으로 즉시 불량표 생성"""
-        defect_key = f"{item_code}_{worker}"
-        if not self.available_defects.get(defect_key):
-            messagebox.showwarning("오류", "선택된 품목의 불량품이 없습니다.")
-            return
-
-        if messagebox.askyesno("불량표 즉시 생성",
-                             f"'{item_code}' 품목의 모든 불량품({len(self.available_defects[defect_key]['barcodes'])}개)으로\n"
-                             f"불량표를 즉시 생성하시겠습니까?"):
-
-            # 임시 세션 생성
-            from core.models import DefectiveMergeSession
-            temp_session = DefectiveMergeSession()
-            temp_session.item_code = item_code
-            temp_session.scanned_defects = list(self.available_defects[defect_key]['barcodes'])
-
-            # 품목 정보 조회
-            matched_item = next((item for item in self.items_data if item.get('Item Code') == item_code), None)
-            if matched_item:
-                temp_session.item_name = matched_item.get('Item Name', item_code)
-                temp_session.item_spec = matched_item.get('Specifications', '')
-            else:
-                temp_session.item_name = item_code
-                temp_session.item_spec = ''
-
-            # 기존 세션 백업
-            original_session = self.current_defective_merge_session
-            self.current_defective_merge_session = temp_session
-
-            try:
-                # 불량표 생성
-                self.generate_defective_label()
-                # 생성 성공 시 해당 불량품을 available_defects에서 제거
-                if defect_key in self.available_defects:
-                    del self.available_defects[defect_key]
-                self.load_all_defective_items()
-                self.show_status_message(f"불량표 즉시 생성 완료", self.COLOR_SUCCESS)
-            finally:
-                # 원래 세션 복원
-                self.current_defective_merge_session = original_session
-
-    def _remove_defects_from_list(self, item_code, worker):
-        """불량품 목록에서 제거"""
-        defect_key = f"{item_code}_{worker}"
-        if messagebox.askyesno("불량품 제거",
-                             f"'{item_code}' 품목의 불량품을 목록에서 제거하시겠습니까?\n"
-                             f"(작업자: {worker}, 수량: {len(self.available_defects.get(defect_key, {}).get('barcodes', set()))}개)"):
-
-            if defect_key in self.available_defects:
-                del self.available_defects[defect_key]
-                self.load_all_defective_items()
-                self.show_status_message(f"'{item_code}' 불량품이 목록에서 제거되었습니다.", self.COLOR_SUCCESS)
-
-                # 현재 세션이 제거된 품목과 같다면 세션 취소
-                if self.current_defective_merge_session.item_code == item_code:
-                    self.cancel_defective_merge_session()
 
     def _create_right_sidebar_content(self, parent_frame):
         parent_frame.grid_columnconfigure(0, weight=1)
@@ -1499,52 +1337,47 @@ class InspectionProgram:
         reworked_barcodes = set()
         processed_defects = set()
 
-        # 실제 로그 폴더 처리
+        if os.path.exists(self.defects_data_folder):
+            for root, _, files in os.walk(self.defects_data_folder):
+                for filename in files:
+                    if filename.endswith('.json'):
+                        try:
+                            with open(os.path.join(root, filename), 'r', encoding='utf-8') as f:
+                                data = json.load(f)
+                                processed_defects.update(data.get('barcodes', []))
+                        except (json.JSONDecodeError, IOError) as e:
+                            print(f"불량 데이터 파일 '{filename}' 처리 중 오류: {e}")
+
         log_folder = self.save_folder
-
-        # 리워크 로그 처리
         rework_log_pattern = re.compile(r"리워크작업이벤트로그_.*\.csv")
-        for filename in os.listdir(log_folder):
-            if rework_log_pattern.match(filename):
-                try:
-                    with open(os.path.join(log_folder, filename), 'r', encoding='utf-8-sig') as f:
-                        reader = csv.DictReader(f)
-                        for row in reader:
-                            if row.get('event') == 'REWORK_SUCCESS':
-                                details = json.loads(row.get('details', '{}'))
-                                if 'barcode' in details:
-                                    reworked_barcodes.add(details['barcode'])
-                except Exception as e:
-                    print(f"리워크 로그 파일 '{filename}' 처리 중 오류: {e}")
+        if os.path.exists(log_folder):
+            for filename in os.listdir(log_folder):
+                if rework_log_pattern.match(filename):
+                    try:
+                        with open(os.path.join(log_folder, filename), 'r', encoding='utf-8-sig') as f:
+                            reader = csv.DictReader(f)
+                            for row in reader:
+                                if row.get('event') == 'REWORK_SUCCESS':
+                                    details = json.loads(row.get('details', '{}'))
+                                    if 'barcode' in details:
+                                        reworked_barcodes.add(details['barcode'])
+                    except Exception as e:
+                        print(f"리워크 로그 파일 '{filename}' 처리 중 오류: {e}")
 
-        # 불량 처리 로그 처리
-        defect_merge_log_pattern = re.compile(r"불량처리로그_.*\.csv")
-        for filename in os.listdir(log_folder):
-            if defect_merge_log_pattern.match(filename):
-                try:
-                    with open(os.path.join(log_folder, filename), 'r', encoding='utf-8-sig') as f:
-                        reader = csv.DictReader(f)
-                        for row in reader:
-                            if row.get('event') == 'DEFECT_MERGE_COMPLETE':
-                                details = json.loads(row.get('details', '{}'))
-                                processed_defects.update(details.get('barcodes', []))
-                except Exception as e:
-                    print(f"불량 처리 로그 파일 '{filename}' 처리 중 오류: {e}")
-
-        # 검사 로그 처리
         inspection_log_pattern = re.compile(r"검사작업이벤트로그_.*\.csv")
-        for filename in os.listdir(log_folder):
-            if inspection_log_pattern.match(filename):
-                try:
-                    with open(os.path.join(log_folder, filename), 'r', encoding='utf-8-sig') as f:
-                        reader = csv.DictReader(f)
-                        for row in reader:
-                            if row.get('event') == 'INSPECTION_DEFECTIVE':
-                                details = json.loads(row.get('details', '{}'))
-                                barcode = details.get('barcode')
-                                if not barcode: continue
+        if os.path.exists(log_folder):
+            for filename in os.listdir(log_folder):
+                if inspection_log_pattern.match(filename):
+                    try:
+                        with open(os.path.join(log_folder, filename), 'r', encoding='utf-8-sig') as f:
+                            reader = csv.DictReader(f)
+                            for row in reader:
+                                if row.get('event') == 'INSPECTION_DEFECTIVE':
+                                    details = json.loads(row.get('details', '{}'))
+                                    barcode = details.get('barcode')
+                                    if not barcode or barcode in reworked_barcodes:
+                                        continue
 
-                                if barcode not in reworked_barcodes and barcode not in processed_defects:
                                     item_code_from_barcode = None
                                     for item in self.items_data:
                                         item_code = item.get('Item Code')
@@ -1553,39 +1386,54 @@ class InspectionProgram:
                                             break
 
                                     if item_code_from_barcode:
-                                        worker_name = row.get('worker', '알수없음')
-                                        defect_key = f"{item_code_from_barcode}_{worker_name}"
-
+                                        defect_key = item_code_from_barcode
                                         if defect_key not in available_defects:
                                             matched_item = next((i for i in self.items_data if i['Item Code'] == item_code_from_barcode), None)
                                             available_defects[defect_key] = {
                                                 'item_code': item_code_from_barcode,
                                                 'name': matched_item.get('Item Name', '알수없음') if matched_item else '알수없음',
                                                 'spec': matched_item.get('Spec', '') if matched_item else '',
-                                                'worker': worker_name,
-                                                'barcodes': set()
+                                                'unprocessed_barcodes': set(),
+                                                'processed_barcodes': set()
                                             }
-                                        available_defects[defect_key]['barcodes'].add(barcode)
-                except Exception as e:
-                    print(f"검사 로그 파일 '{filename}' 처리 중 오류: {e}")
+
+                                        if barcode in processed_defects:
+                                            available_defects[defect_key]['processed_barcodes'].add(barcode)
+                                        else:
+                                            available_defects[defect_key]['unprocessed_barcodes'].add(barcode)
+                    except Exception as e:
+                        print(f"검사 로그 파일 '{filename}' 처리 중 오류: {e}")
 
         self.available_defects = available_defects
         self._update_defective_mode_ui()
         self.show_status_message("불량 데이터 로드 완료.", self.COLOR_SUCCESS)
 
     def _update_defective_mode_ui(self):
-        for i in self.available_defects_tree.get_children():
-            self.available_defects_tree.delete(i)
+        for i in self.unprocessed_defects_tree.get_children():
+            self.unprocessed_defects_tree.delete(i)
+        for i in self.processed_defects_tree.get_children():
+            self.processed_defects_tree.delete(i)
 
-        sorted_items = sorted(self.available_defects.items(), key=lambda item: (item[1]['name'], item[1]['worker']))
-        for defect_key, data in sorted_items:
-            self.available_defects_tree.insert('', 'end', values=(data['name'], data['item_code'], data['worker'], len(data['barcodes'])))
+        sorted_items = sorted(self.available_defects.items(), key=lambda item: item[1]['name'])
+        for item_code, data in sorted_items:
+            unprocessed_count = len(data.get('unprocessed_barcodes', set()))
+            processed_count = len(data.get('processed_barcodes', set()))
+
+            if unprocessed_count > 0:
+                self.unprocessed_defects_tree.insert('', 'end', values=(
+                    data['name'], data['item_code'], unprocessed_count
+                ))
+
+            if processed_count > 0:
+                self.processed_defects_tree.insert('', 'end', values=(
+                    data['name'], data['item_code'], processed_count
+                ), tags=('processed_item',))
 
         session = self.current_defective_merge_session
         if session.item_code:
-            self.defect_session_label.config(text=f"처리 중: {session.item_name} ({session.item_code}) - {len(session.scanned_defects)} / {session.target_quantity}")
+            self.defect_session_label.config(text=f"처리 중: {session.item_name} ({session.item_code}) - {len(session.scanned_defects)}개 스캔됨")
         else:
-            self.defect_session_label.config(text="'불량 합치기'를 시작하거나 불량표를 바로 스캔하세요.")
+            self.defect_session_label.config(text="합칠 불량품/불량표를 스캔하세요. (목록 더블클릭 가능)")
 
         for i in self.scanned_defects_tree.get_children():
             self.scanned_defects_tree.delete(i)
@@ -1593,39 +1441,75 @@ class InspectionProgram:
         for i, barcode in enumerate(session.scanned_defects):
             self.scanned_defects_tree.insert('', 'end', values=(i + 1, barcode))
 
-    def start_defective_merge_session(self):
-        # 왼쪽에서 품목이 선택된 경우 해당 품목으로 세션 시작
-        if self.available_defects_tree.selection():
-            selected_item_id = self.available_defects_tree.selection()[0]
-            item_values = self.available_defects_tree.item(selected_item_id, 'values')
-            item_name = item_values[0]
-            item_code = item_values[1]
-            worker = item_values[2]
-            defect_key = f"{item_code}_{worker}"
-            item_spec = self.available_defects[defect_key]['spec']
+    def _process_manual_defect_scan(self, event=None):
+        """개별 불량 입력 스캔을 처리합니다."""
+        barcode = self.scan_entry_manual_defect.get().strip()
+        if not barcode:
+            return
+        self.scan_entry_manual_defect.delete(0, tk.END)
+        self._record_manual_defect(barcode)
 
-            self.current_defective_merge_session = DefectiveMergeSession(
-                item_code=item_code,
-                item_name=item_name,
-                item_spec=item_spec,
-                target_quantity=int(self.defect_target_qty_spinbox.get())
-            )
-        else:
-            # 품목이 선택되지 않은 경우 빈 세션으로 시작 (불량표/불량품 바코드 스캔으로 자동 설정됨)
-            self.current_defective_merge_session = DefectiveMergeSession(
-                item_code="",  # 첫 번째 스캔으로 결정됨
-                item_name="",  # 첫 번째 스캔으로 결정됨
-                item_spec="",  # 첫 번째 스캔으로 결정됨
-                target_quantity=int(self.defect_target_qty_spinbox.get())
-            )
+    def on_unprocessed_defect_double_click(self, event=None):
+        """미처리 불량품 목록 더블클릭 시 바로 불량 합치기 세션을 시작합니다."""
+        if not self.unprocessed_defects_tree.selection():
+            return
 
-        self.scan_entry_defective.config(state=tk.NORMAL)
+        selection = self.unprocessed_defects_tree.selection()[0]
+        item_values = self.unprocessed_defects_tree.item(selection, 'values')
+        if not item_values:
+            return
+
+        item_code = item_values[1]
+        defect_data = self.available_defects.get(item_code)
+
+        if not defect_data or not defect_data.get('unprocessed_barcodes'):
+            messagebox.showwarning("처리 불가", "해당 품목은 처리할 미처리 불량품이 없습니다.")
+            return
+
+        if self.current_defective_merge_session.item_code and self.current_defective_merge_session.item_code != item_code:
+            if not messagebox.askyesno("세션 변경 확인", "진행 중인 불량 합치기 세션이 있습니다. 새로운 품목으로 세션을 변경하시겠습니까?"):
+                return
+
+        self.current_defective_merge_session = DefectiveMergeSession(
+            item_code=item_code,
+            item_name=defect_data.get('name', ''),
+            item_spec=defect_data.get('spec', '')
+        )
+        self.current_defective_merge_session.scanned_defects.extend(list(defect_data.get('unprocessed_barcodes', [])))
+
         self.cancel_defect_merge_button.config(state=tk.NORMAL)
         self.generate_defect_label_button.config(state=tk.NORMAL)
-        self.start_defect_merge_button.config(state=tk.DISABLED)
-        self.available_defects_tree.config(selectmode=tk.NONE)
-        self._schedule_focus_return()
+
         self._update_defective_mode_ui()
+        self.show_status_message(f"'{item_code}' 불량 합치기를 시작했습니다. ({len(self.current_defective_merge_session.scanned_defects)}개 자동 추가)", self.COLOR_SUCCESS)
+        self._schedule_focus_return()
+
+    def _record_manual_defect(self, barcode: str):
+        """팝업에서 입력된 바코드를 불량품으로 기록합니다."""
+        detected_item_code = None
+        for item in self.items_data:
+            item_code = item.get('Item Code')
+            if item_code and item_code in barcode:
+                detected_item_code = item_code
+                break
+
+        if not detected_item_code:
+            messagebox.showerror("오류", "바코드에서 유효한 품목 코드를 찾을 수 없습니다.")
+            return
+
+        matched_item = next((item for item in self.items_data if item['Item Code'] == detected_item_code), None)
+        item_name = matched_item.get('Item Name', '알 수 없음') if matched_item else '알 수 없음'
+
+        self._log_event('INSPECTION_DEFECTIVE', detail={
+            'barcode': barcode,
+            'item_code': detected_item_code,
+            'item_name': item_name,
+            'direct_scan': True,
+            'scan_time': datetime.datetime.now().isoformat()
+        })
+
+        self.show_status_message(f"'{item_name}' 불량품이 등록되었습니다.", self.COLOR_SUCCESS)
+        self.load_all_defective_items()
 
     def cancel_defective_merge_session(self):
         if self.current_defective_merge_session.scanned_defects:
@@ -1634,11 +1518,9 @@ class InspectionProgram:
 
         self.current_defective_merge_session = DefectiveMergeSession()
 
-        self.scan_entry_defective.config(state=tk.DISABLED)
+        self.scan_entry_defective.delete(0, tk.END)
         self.cancel_defect_merge_button.config(state=tk.DISABLED)
         self.generate_defect_label_button.config(state=tk.DISABLED)
-        self.available_defects_tree.config(selectmode=tk.BROWSE)
-        self.on_available_defect_select()
         self._update_defective_mode_ui()
 
     def _process_defective_merge_scan(self, barcode: str):
@@ -1676,7 +1558,6 @@ class InspectionProgram:
                     session.item_name = matched_item.get('Item Name', '')
                     session.item_spec = matched_item.get('Spec', '')
 
-                session.target_quantity = 48  # 기본 목표 수량
                 self.show_status_message(f"품목 '{session.item_name}' 불량품 통합 세션 자동 시작", self.COLOR_DEFECT, 3000)
                 self._update_defective_mode_ui()
             else:
@@ -1903,8 +1784,9 @@ class InspectionProgram:
             self.scan_entry = self.scan_entry_remnant
         elif is_defective:
             self.defective_view_frame.tkraise()
+            # 불량 모드에서는 기본 포커스를 '불량 합치기' 입력창으로 설정
             self.scan_entry = self.scan_entry_defective
-        else:
+        else: # standard mode
             self.inspection_view_frame.tkraise()
             self.scan_entry = self.scan_entry_inspection
 


### PR DESCRIPTION
사용자 피드백을 반영하여 불량 처리 모드의 UI 레이아웃과 워크플로우를 대폭 개선하고, 관련 없는 코드를 정리했습니다.

주요 변경 사항:
- **UI 레이아웃 재구성:**
  - 불량품 목록을 '미처리'와 '처리완료' 두 개의 독립된 Treeview로 분리하여 상태를 명확히 구분했습니다.
  - '불량 합치기'와 '개별 불량 입력'을 위한 전용 입력창을 각각 분리하여 기능적 역할을 명확히 했습니다.

- **워크플로우 간소화 및 개선:**
  - 미처리 목록의 항목을 더블클릭하면 해당 품목의 모든 미처리 불량품이 자동으로 포함된 합치기 세션이 시작됩니다.
  - 스캔을 통해 '불량 합치기' 또는 '개별 불량 입력'을 바로 시작할 수 있도록 하여 편의성을 높였습니다.
  - 불필요한 버튼과 오른쪽 클릭 메뉴 등 복잡한 UI 요소를 제거하여 사용법을 단순화했습니다.

- **코드 리팩토링 및 안정성 향상:**
  - 각 모드(검사, 불량, 리워크)의 UI가 서로 영향을 주지 않도록 코드를 분리하고 검토하여 안정성을 높였습니다.
  - 불량 데이터 로딩 로직을 개선하여 처리/미처리 상태를 정확하게 반영하도록 수정했습니다.